### PR TITLE
ATF16V8B chips would program & read w/o error, but they wouldn't work

### DIFF
--- a/afterburner.ino
+++ b/afterburner.ino
@@ -1014,9 +1014,9 @@ static void readOrVerifyGal(char verify)
     case ATF16V8B:
         //read without delay, no discard
         if (verify) {
-          i = verifyGalFuseMap(cfgV8, 0, 0);
+          i = verifyGalFuseMap(cfgV8AB, 0, 0);
         } else {
-          readGalFuseMap(cfgV8, 0, 0);
+          readGalFuseMap(cfgV8AB, 0, 0);
         }
         break;
       
@@ -1157,7 +1157,7 @@ static void writeGal()
         break;
       
     case ATF16V8B:
-        writeGalFuseMapV8(cfgV8); 
+        writeGalFuseMapV8(cfgV8AB); 
         break;
 
     case GAL22V10:


### PR DESCRIPTION
ATF16V8B was used cfgV8AB in some places, cfgV8 in others.
The chip would read, and write without error, but wouldn't work.
Changing all instances of cfgV8 to cfgV8AB in ATF16V8B
specific code in afterburner.ino seems to get the programmed
chip to work.