### PR TITLE
Support for ATF22LV10. Fixes issue 11

### DIFF
--- a/afterburner.ino
+++ b/afterburner.ino
@@ -1199,7 +1199,7 @@ static char checkGalTypeViaPes(void)
     Serial.println();
 #endif
 
-    if (pes[7] == 'F' && pes[6]== '2' && pes[5]== '2' && pes[4]== 'V' && pes[3]== '1' && pes[2]=='0') {
+    if (pes[7] == 'F' && pes[6]== '2' && pes[5]== '2' && (pes[4]== 'V' || pes[4]=='L') && pes[3]== '1' && pes[2]=='0') {
        if (pes[1] == 'B') {
            type = ATF22V10B;
        } else {


### PR DESCRIPTION
ATF22LV10 (note the L, it is the 3.3-5V variant) has a different signature (its signature is ATF22L10) but otherwise works the same. With this change, the ATF22LV10 can be used as if it were ATF22L10. I am assuming this works the same for ATF16LV8 but have no parts available to test.