### PR TITLE
Send 'set gal type' before reading PES info bytes. Fixes issue 16

### DIFF
--- a/afterburner.ino
+++ b/afterburner.ino
@@ -114,6 +114,8 @@ typedef enum {
   LAST_GAL_TYPE //dummy
 } GALTYPE;
 
+// help message for command g; must match enum above
+#define GALTYPE_HELPSTR "g1=GAL16V8 g2=GAL20V8 g3=GAL22V10 g4=ATF16V8B g5=ATF22V10B g6=ATF22V10C"
 
 // config bit numbers
 
@@ -240,6 +242,8 @@ void printHelp(char full) {
   Serial.println(F("commands:"));
   Serial.println(F("  h - print help"));
   Serial.println(F("  e - toggle echo")); 
+  Serial.println(F("  g - set GAL type"));
+  Serial.println(F("      " GALTYPE_HELPSTR));
   Serial.println(F("  p - read & print PES"));
   Serial.println(F("  r - read & print fuses"));  
   Serial.println(F("  u - upload fuses"));

--- a/src_pc/afterburner.c
+++ b/src_pc/afterburner.c
@@ -774,18 +774,30 @@ finish:
 
 
 static char operationReadInfo(void) {
-
+    char buf[MAX_LINE];
     char result;
 
     if (openSerial() != 0) {
         return -1;
     }
 
+    // Set gal type
+    sprintf(buf, "g%d\r", (int) gal);
+    if (verbose) {
+        printf("sending 'g' command...\n");
+    }
+    result = sendGenericCommand(buf, "set gal type failed ?", 4000, 0);
+    if (result) {
+        goto finish;
+    }
+    
+    // Read info
     if (verbose) {
         printf("sending 'p' command...\n");
     }
     result = sendGenericCommand("p\r", "info failed ?", 4000, 1);
 
+finish:
     closeSerial();
     return result;
 }


### PR DESCRIPTION
Fixes issue https://github.com/ole00/afterburner/issues/16 .

Send 'set gal type' before reading info bytes in operationReadInfo of PC application
Add 'g' command to help text of Arduino code