### PR TITLE
Prevent closing and re-opening the serial port several times, fixes issue 16 (and probably 18)

### DIFF
--- a/src_pc/afterburner.c
+++ b/src_pc/afterburner.c
@@ -646,10 +646,6 @@ static char upload() {
     char line[64];
     unsigned int i, j, n;
 
-    if (openSerial() != 0) {
-        return -1;
-    }
-
     // Start  upload
     sprintf(buf, "u\r");
     sendLine(buf, MAX_LINE, 20);
@@ -768,7 +764,6 @@ static char operationWriteOrVerify(char doWrite) {
         result = sendGenericCommand("v\r", "verify failed ?", 4000, 0);
     }
 finish:
-    closeSerial();
     return result;
 }
 
@@ -777,16 +772,11 @@ static char operationReadInfo(void) {
 
     char result;
 
-    if (openSerial() != 0) {
-        return -1;
-    }
-
     if (verbose) {
         printf("sending 'p' command...\n");
     }
     result = sendGenericCommand("p\r", "info failed ?", 4000, 1);
 
-    closeSerial();
     return result;
 }
 
@@ -798,10 +788,6 @@ static char operationTestVpp(void) {
 
     char result;
 
-    if (openSerial() != 0) {
-        return -1;
-    }
-
     if (verbose) {
         printf("sending 't' command...\n");
     }
@@ -809,7 +795,6 @@ static char operationTestVpp(void) {
     //Voltage testing takes ~20 seconds
     result = sendGenericCommand("t\r", "info failed ?", 22000, 1);
 
-    closeSerial();
     return result;
 }
 
@@ -817,11 +802,7 @@ static char operationSetGalCheck(void) {
     int readSize;
     char result;
 
-    if (openSerial() != 0) {
-        return -1;
-    }
     result = sendGenericCommand(noGalCheck ? "F\r" : "f\r", "noGalCheck failed ?", 4000, 0);
-    closeSerial();
     return result;    
 }
 
@@ -830,12 +811,8 @@ static char operationSetGalType(Galtype type) {
     int readSize;
     char result;
 
-    if (openSerial() != 0) {
-        return -1;
-    }
     sprintf(buf, "g%i\r", (int)type); 
     result = sendGenericCommand(buf, "setGalType failed ?", 4000, 0);
-    closeSerial();
     return result;    
 }
 
@@ -844,10 +821,6 @@ static char operationEraseGal(void) {
     char buf[MAX_LINE];
     int readSize;
     char result;
-
-    if (openSerial() != 0) {
-        return -1;
-    }
 
     //Switch to upload mode to specify GAL
     sprintf(buf, "u\r");
@@ -863,7 +836,6 @@ static char operationEraseGal(void) {
 
     result = sendGenericCommand("c\r", "erase failed ?", 4000, 0);
 
-    closeSerial();
     return result;
 }
 
@@ -871,10 +843,6 @@ static char operationReadFuses(void) {
     char* response;
     char* buf = galbuffer;
     int readSize;
-
-    if (openSerial() != 0) {
-        return -1;
-    }
 
     //Switch to upload mode to specify GAL
     sprintf(buf, "u\r");
@@ -897,8 +865,6 @@ static char operationReadFuses(void) {
     response = stripPrompt(buf);
     printf("%s\n", response);
 
-    closeSerial();
-
     if (response[0] == 'E' && response[1] == 'R') {
         return -1;
     }
@@ -918,7 +884,11 @@ int main(int argc, char** argv) {
         printf("Afterburner " VERSION " \n");
     }
 
-    result = operationSetGalCheck();
+    result = openSerial();
+    
+    if (0 == result) {
+        result = operationSetGalCheck();
+    }
 
     if (gal != UNKNOWN && 0 == result) {
         result = operationSetGalType(gal);
@@ -943,6 +913,8 @@ int main(int argc, char** argv) {
             result = operationTestVpp();
         }
     }
+
+    closeSerial();
 
     if (verbose) {
         printf("result=%i\n", (char)result);


### PR DESCRIPTION
Instead of opening and closing the serial port for every step, do it only once. This solves the issues related to the arduino resetting in between, and speeds up the programming since each resets costs a few seconds (may be depending on the Arduino type)

With this PR, the changes related to the 'noinit' of the Arduino gal variable could be reverted; I can make a commit for this if desired.