### PR TITLE
Support ST GAL16V8

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Supported GAL chips:
 * Lattice GAL16V8A, GAL16V8B, GAL16V8D
 * Lattice GAL22V10B, GAL22V10D
 * National GAL16V8
+* ST Microsystems GAL16V8
 * Lattice GAL20V8B (no adapter needed)
 
 **This is a new Afterburner design with variable programming voltage control and with single ZIF socket for 20 and 24 pin GAL chips.**

--- a/afterburner.ino
+++ b/afterburner.ino
@@ -1658,6 +1658,8 @@ static char checkGalTypeViaPes(void)
        for (type = (sizeof(galinfo) / sizeof(galinfo[0])) - 1; type; type--) {
            if (pes[2] == galinfo[type].id0 || pes[2] == galinfo[type].id1) break;
        }
+    } else if (pes[3] == SGSTHOMSON && pes[2] == 0x00) {
+      type = GAL16V8;
     }
 
     return type;

--- a/afterburner.ino
+++ b/afterburner.ino
@@ -1659,7 +1659,7 @@ static char checkGalTypeViaPes(void)
            if (pes[2] == galinfo[type].id0 || pes[2] == galinfo[type].id1) break;
        }
     } else if (pes[3] == SGSTHOMSON && pes[2] == 0x00) {
-      type = GAL16V8;
+       type = GAL16V8;
     }
 
     return type;


### PR DESCRIPTION
ST GAL16V8 has PES[2] = 0

Writing and reading back jed files from [https://rhgndf.github.io/galasm-web/](https://rhgndf.github.io/galasm-web/) works. Same checksum when read back.