### PR TITLE
Reduce ram usage

### DIFF
--- a/afterburner.ino
+++ b/afterburner.ino
@@ -316,7 +316,7 @@ static uint8_t vpp = 0;
 
 char echoEnabled;
 unsigned char pes[12];
-char line[128];
+char line[40];
 short lineIndex;
 char endOfLine;
 char mapUploaded;
@@ -555,7 +555,7 @@ char handleTerminalCommands() {
       lineIndex = 0;
       readGarbage();
       Serial.println();
-      Serial.println("Error: line too long.");
+      Serial.println(F("Error: line too long."));
     } else {
       lineIndex++;
     }
@@ -2157,30 +2157,34 @@ static void printGalName() {
 }
 
 static unsigned printJedecBlock(unsigned short k, unsigned short bits, unsigned short rows) {
-  unsigned short i, j, n;
+  unsigned short i, j;
   unsigned char unused;
 
   for (i = 0; i < bits; i++)
   {
-      n = 0;
       unused = 1;
-      line[n++] = 'L';
-      n = addFormatedNumberDec4(k, n);
-      line[n++] = ' ';
+      for (j = 0; j < rows; j++)
+      {
+        unused &= !getFuseBit(k + j);
+      }
+      if (unused) {
+        k += rows;
+        continue;
+      }
+
+      Serial.print('L');
+      printFormatedNumberDec4(k);
+      Serial.print(' ');
       for (j = 0; j < rows; j++, k++)
       {
           if (getFuseBit(k)) {
               unused = 0;
-              line[n++] = '1';
+              Serial.print('1');
           } else {
-              line[n++] = '0';
+              Serial.print('0');
           }
       }
-      line[n++] = '*';
-      line[n++] = 0;
-      if (!unused) {
-        Serial.println(line);
-      }
+      Serial.println('*');
   }
   return k;
 }

--- a/afterburner.ino
+++ b/afterburner.ino
@@ -316,7 +316,7 @@ static uint8_t vpp = 0;
 
 char echoEnabled;
 unsigned char pes[12];
-char line[40];
+char line[32];
 short lineIndex;
 char endOfLine;
 char mapUploaded;
@@ -2211,28 +2211,21 @@ static void printJedec()
     }
 
     if( k < galinfo[gal].uesfuse) {
-        unused = 1;
-        n = 0;
-        line[n++] = 'L';
-        n = addFormatedNumberDec4(k, n);
-        line[n++] = ' ';
+        Serial.print('L');
+        printFormatedNumberDec4(k);
+        Serial.print(' ');
         
         while(k < galinfo[gal].uesfuse) {
            if (getFuseBit(k)) {
               unused = 0;
-              line[n++] = '1';
+              Serial.print('1');
            } else {
-              line[n++] = '0';
+              Serial.print('0');
            }
            k++;
         }
-        line[n++] = '*';
-        line[n++] = 0;
-        if (!unused) {
-          Serial.println(line);
-        }
+        Serial.println('*');
     }
-    line[0] = 0;
 
 
     // UES in byte form

--- a/afterburner.ino
+++ b/afterburner.ino
@@ -1124,25 +1124,15 @@ static void writePes(void) {
   turnOff();
 }
 
+static const unsigned char PROGMEM duration[] = {
+  1, 2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200
+};
 
 static unsigned char getDuration(unsigned char index) {
-  switch (index) {
-    case 0: return 1;
-    case 1: return 2;
-    case 2: return 5;
-    case 3: return 10;
-    case 4: return 20;
-    case 5: return 30;
-    case 6: return 40;
-    case 7: return 50;
-    case 8: return 60;
-    case 9: return 70;
-    case 10: return 80;
-    case 11: return 90;
-    case 12: return 100;
-    case 13: return 200;
-    default: return 0;
+  if (index > 13) {
+    return 0;
   }
+  return pgm_read_byte(&duration[index]);
 }
 
 static void setGalDefaults(void) {


### PR DESCRIPTION
This could save a bit more ram when uploaded into a UNO. I'm using an arduino mega, so just looking at whether global variables use exceeds 2048. With this PR it is at 1551 bytes.

There seems to be a switch table generated by getDuration which is placed in ram and unfortunately, there is no way to put it in PROGMEM: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=49857
Replacing it with a PROGMEM array instead.

Putting PROGMEM on galinfo does not work out of the box.

Check whether line[32] is enough.